### PR TITLE
Enhance README and add secrets management in Terraform

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,18 @@ container-arch--aws-ecs--app/ .github/ workflows/ dev.yml .gitignore app/ Docker
    terraform init
    ```
 
-3. Apply the Terraform configuration:
+3. Apply the Terraform configuration deploying all the necessary infrastructure:
+
+   PS: For this step, it is needed to have cloned the repositories [container-arch--aws-ecs--module](git@github.com:therenanlira/container-arch--aws-ecs--module.git) and [container-arch--aws-ecs--cluster](git@github.com:therenanlira/container-arch--aws-ecs--cluster.git) as well.
 
    ```sh
-   terraform apply -var-file="environment/dev/terraform.tfvars"
+   ./tf-container-arch.sh
+   ```
+
+4. Apply only changes made to the app or to the infrastructure in the repository [container-arch--aws-ecs--app](git@github.com:therenanlira/container-arch--aws-ecs--app.git)
+
+   ```sh
+   ./pipeline.sh
    ```
 
 ### Scripts

--- a/app/main.go
+++ b/app/main.go
@@ -113,7 +113,13 @@ func main() {
     }
 
     return c.SendStatus(fiber.StatusNoContent)
-})
+	})
+
+	app.Get("/printenv", func (c *fiber.Ctx) error {
+		return c.JSON(fiber.Map{
+			"env": os.Environ(),
+		})
+	})
 
 	_ = app.Listen(":8080")
 }

--- a/burn-cpu.sh
+++ b/burn-cpu.sh
@@ -2,7 +2,7 @@
 
 burn_cpu() {
   while true; do
-    curl "http://linuxtips-ecscluster--alb-1158440245.us-east-1.elb.amazonaws.com/burn/cpu" -H "chip.linuxtips.demo" -1;
+    curl "http://linuxtips-ecscluster--alb-1260780213.us-east-1.elb.amazonaws.com/burn/cpu" -H "chip.linuxtips.demo" -1;
     echo
   done
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,5 +1,5 @@
 module "service" {
-  source = "git@github.com:therenanlira/container-arch--aws-ecs--module.git?ref=v1.2.0"
+  source = "git@github.com:therenanlira/container-arch--aws-ecs--module.git?ref=v1.3.0"
   region = var.region
 
   container_image = var.container_image
@@ -23,6 +23,17 @@ module "service" {
 
   environment_variables = var.environment_variables
   capabilities          = var.capabilities
+
+  secrets = [
+    {
+      name      = "SSM_PARAMETER_VALUE_VARIABLE"
+      valueFrom = aws_ssm_parameter.parameter.arn
+    },
+    {
+      name      = "SECRET_MANAGER_VALUE_VARIABLE"
+      valueFrom = aws_secretsmanager_secret.secret.arn
+    }
+  ]
 
   scale_type   = var.scale_type
   task_minimum = var.task_minimum

--- a/terraform/parameter.tf
+++ b/terraform/parameter.tf
@@ -1,0 +1,9 @@
+locals {
+  parameter_resource_name = "${var.cluster_name}--${var.service_name}"
+}
+
+resource "aws_ssm_parameter" "parameter" {
+  name  = "${local.parameter_resource_name}--parameter"
+  type  = "String"
+  value = "Parameter Store v1"
+}

--- a/terraform/secret_manager.tf
+++ b/terraform/secret_manager.tf
@@ -1,0 +1,12 @@
+locals {
+  secretmanager_resource_name = "${var.cluster_name}--${var.service_name}"
+}
+
+resource "aws_secretsmanager_secret" "secret" {
+  name = "${local.secretmanager_resource_name}--secret"
+}
+
+resource "aws_secretsmanager_secret_version" "secret_version" {
+  secret_id     = aws_secretsmanager_secret.secret.id
+  secret_string = "Secret Manager v1"
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -77,6 +77,15 @@ variable "environment_variables" {
   }))
 }
 
+variable "secrets" {
+  type = list(object({
+    name      = string
+    valueFrom = string
+  }))
+  description = "Secret Manager or Parameter Store list of secrets"
+  default     = []
+}
+
 variable "capabilities" {
   description = "The capabilities for the task definition"
   type        = list(string)


### PR DESCRIPTION
Update the README with setup instructions and introduce a new `/printenv` endpoint. Improve Terraform configuration for managing secrets using AWS SSM and Secrets Manager.